### PR TITLE
bevy 0.15 rc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ name = "render_egui_to_texture"
 required-features = ["render"]
 
 [dependencies]
-bevy = { version = "0.15.0-dev", default-features = false, features = [
+bevy = { version = "0.15.0-rc.2", default-features = false, features = [
     "bevy_asset",
     "bevy_winit",
 ] }
@@ -59,15 +59,18 @@ arboard = { version = "3.2.0", optional = true }
 thread_local = { version = "1.1.0", optional = true }
 
 [dev-dependencies]
-version-sync = "0.9.4"
-bevy = { version = "0.15.0-dev", default-features = false, features = [
+# 0.15.0-rc.1
+# 0.15.0-dev
+bevy = { version = "0.15.0-rc.2", default-features = false, features = [
     "x11",
     "png",
     "bevy_pbr",
     "bevy_core_pipeline",
     "tonemapping_luts",
     "webgl2",
+    "custom_cursor",
 ] }
+version-sync = "0.9.4"
 egui = { version = "0.28", default-features = false, features = ["bytemuck"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
@@ -92,4 +95,19 @@ crossbeam-channel = "0.5.8"
 members = ["run-wasm"]
 
 [patch.crates-io]
-bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0114c44c9f00a2e9c41db1225aaa78d15" }
+# doesnt work:
+# bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "a2b53d46e73b98f7f5d074ed2bb8ddfedfcc5d4d" }
+# doesnt work:
+#bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "cab00766d99c2bf0519464a60e8a91e05c83d0fd" }
+# doesnt work:
+# bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "1df8238e8d8fe968d682468301ad4140c95b7604" }
+# doesnt work, breakage appears here!
+# bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "56f8e526dde49b4e4ad62efb7ad27bfe0bd6f617" }
+# works:
+# bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "01dce4742f77a572a1ef21ce8f64ce3b6d2328a8" }
+# works:
+# bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "7ee5143d45f9246f9cffc52e916ae12d85a71779" }
+# works:
+# bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "3139b03e7400313d947dc912e12d7c2d98207653" }
+# works:
+#bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "9386bd0114c44c9f00a2e9c41db1225aaa78d15" }

--- a/examples/paint_callback.rs
+++ b/examples/paint_callback.rs
@@ -101,6 +101,7 @@ impl EguiBevyPaintCallbackImpl for CustomPaintCallback {
                     .and_then(|cache| cache.get_render_pipeline(comp.pipeline_id))
             })
         else {
+            warn!("Could not find pipeline.");
             return;
         };
 

--- a/examples/render_egui_to_texture.rs
+++ b/examples/render_egui_to_texture.rs
@@ -49,21 +49,20 @@ fn setup_worldspace(
         output_texture
     });
 
-    commands.spawn(PbrBundle {
-        mesh: meshes.add(Cuboid::new(1.0, 1.0, 1.0).mesh()),
-        material: materials.add(StandardMaterial {
+    commands.spawn((
+        Mesh3d(meshes.add(Cuboid::new(1.0, 1.0, 1.0).mesh())),
+        MeshMaterial3d(materials.add(StandardMaterial {
             base_color: Color::WHITE,
             base_color_texture: Some(Handle::clone(&output_texture)),
             alpha_mode: AlphaMode::Blend,
             // Remove this if you want it to use the world's lighting.
             unlit: true,
             ..default()
-        }),
-        ..default()
-    });
+        })),
+    ));
     commands.spawn(EguiRenderToTextureHandle(output_texture));
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(1.5, 1.5, 1.5).looking_at(Vec3::new(0., 0., 0.), Vec3::Y),
-        ..default()
-    });
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(1.5, 1.5, 1.5).looking_at(Vec3::new(0., 0., 0.), Vec3::Y),
+    ));
 }

--- a/examples/render_to_image_widget.rs
+++ b/examples/render_to_image_widget.rs
@@ -82,37 +82,36 @@ fn setup(
 
     // The cube that will be rendered to the texture.
     commands
-        .spawn(PbrBundle {
-            mesh: cube_handle,
-            material: preview_material_handle,
-            transform: Transform::from_translation(Vec3::new(0.0, 0.0, 1.0)),
-            ..default()
-        })
+        .spawn((
+            Mesh3d(cube_handle),
+            MeshMaterial3d(preview_material_handle),
+            Transform::from_translation(Vec3::new(0.0, 0.0, 1.0)),
+        ))
         .insert(PreviewPassCube)
         .insert(preview_pass_layer.clone());
 
     // The same light is reused for both passes,
     // you can specify different lights for preview and main pass by setting appropriate RenderLayers.
     commands
-        .spawn(PointLightBundle {
-            transform: Transform::from_translation(Vec3::new(0.0, 0.0, 10.0)),
-            ..default()
-        })
+        .spawn((
+            PointLight::default(),
+            Transform::from_translation(Vec3::new(0.0, 0.0, 10.0)),
+        ))
         .insert(RenderLayers::default().with(1));
 
     commands
-        .spawn(Camera3dBundle {
-            camera: Camera {
+        .spawn((
+            Camera3d::default(),
+            Camera {
                 // render before the "main pass" camera
                 order: -1,
                 target: RenderTarget::Image(image_handle),
                 clear_color: ClearColorConfig::Custom(Color::srgba(1.0, 1.0, 1.0, 0.0)),
                 ..default()
             },
-            transform: Transform::from_translation(Vec3::new(0.0, 0.0, 15.0))
+            Transform::from_translation(Vec3::new(0.0, 0.0, 15.0))
                 .looking_at(Vec3::default(), Vec3::Y),
-            ..default()
-        })
+        ))
         .insert(preview_pass_layer);
 
     let cube_size = 4.0;
@@ -122,30 +121,28 @@ fn setup(
 
     // Main pass cube.
     commands
-        .spawn(PbrBundle {
-            mesh: cube_handle,
-            material: main_material_handle,
-            transform: Transform {
+        .spawn((
+            Mesh3d(cube_handle),
+            MeshMaterial3d(main_material_handle),
+            Transform {
                 translation: Vec3::new(0.0, 0.0, 1.5),
                 rotation: Quat::from_rotation_x(-std::f32::consts::PI / 5.0),
                 ..default()
             },
-            ..default()
-        })
+        ))
         .insert(MainPassCube);
 
     // The main pass camera.
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_translation(Vec3::new(0.0, 0.0, 15.0))
-            .looking_at(Vec3::default(), Vec3::Y),
-        ..default()
-    });
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_translation(Vec3::new(0.0, 0.0, 15.0)).looking_at(Vec3::default(), Vec3::Y),
+    ));
 }
 
 fn render_to_image_example_system(
     cube_preview_image: Res<CubePreviewImage>,
-    preview_cube_query: Query<&Handle<StandardMaterial>, With<PreviewPassCube>>,
-    main_cube_query: Query<&Handle<StandardMaterial>, With<MainPassCube>>,
+    preview_cube_query: Query<&MeshMaterial3d<StandardMaterial>, With<PreviewPassCube>>,
+    main_cube_query: Query<&MeshMaterial3d<StandardMaterial>, With<MainPassCube>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
     mut contexts: EguiContexts,
 ) {
@@ -225,7 +222,7 @@ fn rotator_system(
     mut query: Query<&mut Transform, Or<(With<PreviewPassCube>, With<MainPassCube>)>>,
 ) {
     for mut transform in &mut query {
-        transform.rotate_x(1.5 * time.delta_seconds());
-        transform.rotate_z(1.3 * time.delta_seconds());
+        transform.rotate_x(1.5 * time.delta_secs());
+        transform.rotate_z(1.3 * time.delta_secs());
     }
 }

--- a/examples/side_panel.rs
+++ b/examples/side_panel.rs
@@ -88,36 +88,30 @@ fn setup_system(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    commands.spawn(PbrBundle {
-        mesh: meshes.add(Plane3d::default().mesh().size(5.0, 5.0)),
-        material: materials.add(Color::srgb(0.3, 0.5, 0.3)),
-        ..Default::default()
-    });
-    commands.spawn(PbrBundle {
-        mesh: meshes.add(Cuboid::new(1.0, 1.0, 1.0)),
-        material: materials.add(Color::srgb(0.8, 0.7, 0.6)),
-        transform: Transform::from_xyz(0.0, 0.5, 0.0),
-        ..Default::default()
-    });
-    commands.spawn(PointLightBundle {
-        point_light: PointLight {
+    commands.spawn((
+        Mesh3d(meshes.add(Plane3d::default().mesh().size(5.0, 5.0))),
+        MeshMaterial3d(materials.add(Color::srgb(0.3, 0.5, 0.3))),
+    ));
+    commands.spawn((
+        Mesh3d(meshes.add(Cuboid::new(1.0, 1.0, 1.0))),
+        MeshMaterial3d(materials.add(Color::srgb(0.8, 0.7, 0.6))),
+        Transform::from_xyz(0.0, 0.5, 0.0),
+    ));
+    commands.spawn((
+        PointLight {
             intensity: 1500.0,
             shadows_enabled: true,
             ..Default::default()
         },
-        transform: Transform::from_xyz(4.0, 8.0, 4.0),
-        ..Default::default()
-    });
+        Transform::from_xyz(4.0, 8.0, 4.0),
+    ));
 
     let camera_pos = Vec3::new(-2.0, 2.5, 5.0);
     let camera_transform =
         Transform::from_translation(camera_pos).looking_at(CAMERA_TARGET, Vec3::Y);
     commands.insert_resource(OriginalCameraTransform(camera_transform));
 
-    commands.spawn(Camera3dBundle {
-        transform: camera_transform,
-        ..Default::default()
-    });
+    commands.spawn((Camera3d::default(), camera_transform));
 }
 
 fn update_camera_transform_system(

--- a/examples/two_windows.rs
+++ b/examples/two_windows.rs
@@ -35,14 +35,14 @@ fn create_new_window_system(mut commands: Commands) {
         .id();
 
     // second window camera
-    commands.spawn(Camera3dBundle {
-        camera: Camera {
+    commands.spawn((
+        Camera3d::default(),
+        Camera {
             target: RenderTarget::Window(WindowRef::Entity(second_window_id)),
             ..Default::default()
         },
-        transform: Transform::from_xyz(6.0, 0.0, 0.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..Default::default()
-    });
+        Transform::from_xyz(6.0, 0.0, 0.0).looking_at(Vec3::ZERO, Vec3::Y),
+    ));
 }
 
 fn load_assets_system(mut commands: Commands, assets: Res<AssetServer>) {

--- a/examples/two_windows.rs
+++ b/examples/two_windows.rs
@@ -70,6 +70,7 @@ fn ui_first_window_system(
 ) {
     let bevy_texture_id = egui_user_textures.add_image(images.bevy_icon.clone_weak());
     let Ok(mut ctx) = egui_ctx.get_single_mut() else {
+        warn!("Could not find ctx.");
         return;
     };
     egui::Window::new("First Window")
@@ -100,6 +101,7 @@ fn ui_second_window_system(
 ) {
     let bevy_texture_id = egui_user_textures.add_image(images.bevy_icon.clone_weak());
     let Ok(mut ctx) = egui_ctx.get_single_mut() else {
+        warn!("Could not find ctx(2).");
         return;
     };
     egui::Window::new("Second Window")

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -1,7 +1,8 @@
 use bevy::{
+    log::{Level, LogPlugin},
     prelude::*,
-    render::view::cursor::CursorIcon,
     window::{PrimaryWindow, SystemCursorIcon},
+    winit::cursor::CursorIcon,
 };
 use bevy_egui::{EguiContexts, EguiPlugin, EguiSettings};
 
@@ -28,19 +29,30 @@ fn main() {
     App::new()
         .insert_resource(ClearColor(Color::BLACK))
         .init_resource::<UiState>()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(Window {
-                prevent_default_event_handling: false,
-                ..default()
-            }),
-            ..default()
-        }))
+        .add_plugins(
+            DefaultPlugins
+                .set(LogPlugin {
+                    filter: "warn,ui=info".to_string(),
+                    level: Level::INFO,
+                    ..Default::default()
+                })
+                .set(WindowPlugin {
+                    primary_window: Some(Window {
+                        prevent_default_event_handling: false,
+                        ..default()
+                    }),
+                    ..default()
+                }),
+        )
         .add_plugins(EguiPlugin)
         .add_systems(Startup, configure_cursor)
         .add_systems(Startup, configure_visuals_system)
         .add_systems(Startup, configure_ui_state_system)
         .add_systems(Update, update_ui_scale_factor_system)
         .add_systems(Update, ui_example_system)
+        .add_systems(PreUpdate, || {
+            info!("new frame:");
+        })
         .run();
 }
 #[derive(Default, Resource)]

--- a/src/egui_render_to_texture_node.rs
+++ b/src/egui_render_to_texture_node.rs
@@ -8,7 +8,6 @@ use crate::{
 };
 use bevy::{
     ecs::world::World,
-    prelude::Entity,
     render::{
         render_asset::RenderAssets,
         render_graph::{Node, NodeRunError, RenderGraphContext, RenderLabel},
@@ -177,7 +176,7 @@ impl Node for EguiRenderToTextureNode {
 
             let texture_handle = match mesh.texture_id {
                 egui::TextureId::Managed(id) => {
-                    EguiTextureId::Managed(self.render_to_texture_target_render.id(), id)
+                    EguiTextureId::Managed(self.render_to_texture_target_main, id)
                 }
                 egui::TextureId::User(id) => EguiTextureId::User(id),
             };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,8 +121,8 @@ use bevy::{
         SystemSet, With, Without,
     },
     reflect::Reflect,
-    render::view::cursor::CursorIcon,
     window::{PrimaryWindow, Window},
+    winit::cursor::CursorIcon,
 };
 #[cfg(all(
     feature = "manage_clipboard",

--- a/src/render_systems.rs
+++ b/src/render_systems.rs
@@ -104,19 +104,19 @@ pub fn setup_new_windows_render_system(
 }
 /// Sets up the pipeline for newly created Render to texture entities.
 pub fn setup_new_rtt_render_system(
-    render_to_texture_targets: Extract<Query<Entity, Added<EguiRenderToTextureHandle>>>,
+    render_to_texture_targets: Extract<
+        Query<(Entity, &RenderEntity), Added<EguiRenderToTextureHandle>>,
+    >,
     mut render_graph: ResMut<RenderGraph>,
 ) {
-    for render_to_texture_target in render_to_texture_targets.iter() {
+    for (render_to_texture_target, render_entity) in render_to_texture_targets.iter() {
         let egui_rtt_pass = EguiRenderToTexturePass {
             entity_index: render_to_texture_target.index(),
             entity_generation: render_to_texture_target.generation(),
         };
 
         let new_node = EguiRenderToTextureNode::new(
-            // FIXME: this RenderEntity is incorrect!
-            RenderEntity::from(render_to_texture_target),
-            //
+            *render_entity,
             MainEntity::from(render_to_texture_target),
         );
 

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -92,7 +92,7 @@ impl<'w, 's> ContextSystemParams<'w, 's> {
             }
             Err(
                 err @ QueryEntityError::NoSuchEntity(_)
-                | err @ QueryEntityError::QueryDoesNotMatch(_),
+                | err @ QueryEntityError::QueryDoesNotMatch(_, _),
             ) => {
                 log::error!("Failed to get an Egui context for a window ({window:?}): {err:?}",);
                 None
@@ -427,7 +427,7 @@ pub fn process_input_system(
 
     for mut context in context_params.contexts.iter_mut() {
         context.egui_input.modifiers = modifiers;
-        context.egui_input.time = Some(time.elapsed_seconds_f64());
+        context.egui_input.time = Some(time.elapsed_secs_f64());
     }
 
     // In some cases, we may skip certain events. For example, we ignore `ReceivedCharacter` events
@@ -539,7 +539,7 @@ pub fn process_output_system(
 
         if let Some(mut cursor) = context.cursor {
             let mut set_icon = || {
-                *cursor = bevy::render::view::cursor::CursorIcon::System(
+                *cursor = bevy::winit::cursor::CursorIcon::System(
                     egui_to_winit_cursor_icon(platform_output.cursor_icon)
                         .unwrap_or(bevy::window::SystemCursorIcon::Default),
                 );


### PR DESCRIPTION
Something is rendering! but still mostly broken.

# Analysis

- https://github.com/bevyengine/bevy/pull/15320 broke https://github.com/mvlabat/bevy_egui/pull/309

Entities are used all over bevy_egui to refer to items:

- EguiPipelines
- EguiNode
- EguiRenderToTextureNode (let's ignore that for now)
- EguiPass

To me, it seems that most entities should refer to render world's.

But the source to get these Entities are sometimes `ExtractedWindows`, which is from main world: 

- https://github.com/mvlabat/bevy_egui/blob/main/src/render_systems.rs#L254-L270 


Questions:

Which world should our key entities be from ?


## RenderEntity

Since most operations are from the render schedules, I think it makes sense to be on `RenderEntity`.

Not blocking: We can't use `RenderEntity` as a key because Eq and Hash are not derived. We could reimplement our own but it's an annoyance.
This should be fixed by https://github.com/bevyengine/bevy/pull/16191 

Blocking (?): When in `queue_pipelines_system`, our window doesn't have a `RenderEntity`, so it's difficult to add a `RenderEntity` key.

TODO: ? we could try to replace the window extract (which I believe comes from bevy), to create our own extraction logic which would occur earlier, but I fear this would result in surprises for users. (and I'm not sure it's possible).

## MainEntity

So if I can´t rely on RenderEntity, let's try to rely on the Entity from main world:

`EguiRenderToTextureNode::render_to_texture_target` is split into 2 entities, to keep links at all times.

unfortunately this doesn´t work, I'm not sure where the error is.

I'll hunt for error handling in case of entities not found and add more debug while I think of better debugging strategy :thinking:

### Debugging attempt

- I notice that `EguiNode::update()` is never called, I guess that suggests a wrong use of bevy's API.
  - changelog from https://bevyengine.org/learn/migration-guides/0-14-to-0-15/ mentions UINode changes, related to parent/child, it doesn't seem relevant to our use case :(